### PR TITLE
Also supply `-optc-Wno-format-security`

### DIFF
--- a/HsSyck.cabal
+++ b/HsSyck.cabal
@@ -37,7 +37,7 @@ Library
 
     exposed-modules: Data.Yaml.Syck
 
-    ghc-options: -funbox-strict-fields -optc-Wno-int-conversion -optc-Wno-deprecated-non-prototype -optc-Wno-format
+    ghc-options: -funbox-strict-fields -optc-Wno-int-conversion -optc-Wno-deprecated-non-prototype -optc-Wno-format -optc-Wno-format-security
 
 
     c-sources: syck/bytecode.c syck/emitter.c syck/gram.c syck/handler.c


### PR DESCRIPTION
Something changed in https://github.com/audreyt/hssyck/commit/e7f3cca33b6b80005d8cb25a0a2f4948730989a2 to now cause 0.54 to fail, with:

```
       > Configuring library for HsSyck-0.54..
       > cc1: error: ‘-Wformat-security’ ignored without ‘-Wformat’ [-Werror=format-security]
       > cc1: note: unrecognized command-line option ‘-Wno-deprecated-non-prototype’ may have been intended to silence earlier diagnostics
       > cc1: some warnings being treated as errors
       > `cc' failed in phase `C Compiler'. (Exit code: 1)
```

I'm not sure why this only happens now, but supplying `-Wno-format-security` fixes this.