### PR TITLE
Fix build with GCC 15

### DIFF
--- a/HsSyck.cabal
+++ b/HsSyck.cabal
@@ -37,7 +37,8 @@ Library
 
     exposed-modules: Data.Yaml.Syck
 
-    ghc-options: -funbox-strict-fields -optc-Wno-int-conversion -optc-Wno-deprecated-non-prototype -optc-Wno-format -optc-Wno-format-security
+    ghc-options: -funbox-strict-fields -optc-Wno-int-conversion -optc-Wno-deprecated-non-prototype -optc-Wno-format -optc-Wno-format-security -optc--std=gnu11
+
 
 
     c-sources: syck/bytecode.c syck/emitter.c syck/gram.c syck/handler.c


### PR DESCRIPTION
GCC 15 bumped the default c version which makes the c code in this package fail to compile. We can fix this by explicitly specifying the version.